### PR TITLE
Hack around static front matter titles

### DIFF
--- a/content/en/docs/01/_index.md
+++ b/content/en/docs/01/_index.md
@@ -1,6 +1,5 @@
 ---
 title: "1. Quick tour of Kubernetes"
-#title: "1. Quick tour of OpenShift"
 weight: 1
 sectionnumber: 1
 ---

--- a/layouts/docs/list.html
+++ b/layouts/docs/list.html
@@ -1,13 +1,13 @@
 {{ define "main" }}
 <div class="td-content">
-	<h1>{{ .Title }}</h1>
+	<h1>{{ replace .Title "Kubernetes" .Site.Params.distroName }}</h1>
         {{ with .Params.description }}<div class="lead">{{ . | markdownify }}</div>{{ end }}
 	{{ if (and (not .Params.hide_readingtime) (.Site.Params.ui.readingtime.enable)) }}
             {{ partial "reading-time.html" . }}
         {{ end }}
 	{{ .Content }}
         {{ partial "section-index.html" . }}
-  <div>{{ partial "prevnextlinks.html" . }}</div>
+  	<div>{{ partial "prevnextlinks.html" . }}</div>
 	{{ if (and (not .Params.hide_feedback) (.Site.Params.ui.feedback.enable) (.Site.GoogleAnalytics)) }}
 		{{ partial "feedback.html" .Site.Params.ui.feedback }}
 		<br />

--- a/layouts/partials/section-index.html
+++ b/layouts/partials/section-index.html
@@ -1,0 +1,30 @@
+{{/* Copied and adapted from themes/docsy/layouts/partials/sidebar-tree.html */}}
+<div class="section-index">
+    {{ $pages := (where .Site.Pages "Section" .Section).ByWeight }}
+    {{ $parent := .Page }}
+    {{ if $parent.Params.no_list }}
+    {{/* If no_list is true we don't show a list of subpages */}}
+    {{ else if $parent.Params.simple_list }}
+    {{/* If simple_list is true we show a bulleted list of subpages */}}
+        <ul>
+            {{ range $pages }}
+                {{ if eq .Parent $parent }}
+                    <li><a href="{{ .RelPermalink }}">{{- replace .Title "Kubernetes" .Site.Params.distroName -}}</a></li>
+                {{ end }}
+            {{ end }}
+        </ul>
+    {{ else }}
+    {{/* Otherwise we show a nice formatted list of subpages with page descriptions */}}
+    <hr class="panel-line">
+        {{ range $pages }}
+            {{ if eq .Parent $parent }}
+                <div class="entry">
+                    <h5>
+                        <a href="{{ .RelPermalink }}">{{- replace .Title "Kubernetes" .Site.Params.distroName -}}</a>
+                    </h5>
+                    <p>{{ .Description | markdownify }}</p>
+                </div>
+            {{ end }}
+        {{ end }}
+    {{ end }}
+</div>

--- a/layouts/partials/sidebar-tree.html
+++ b/layouts/partials/sidebar-tree.html
@@ -27,7 +27,7 @@
 {{ $sid := $s.RelPermalink | anchorize }}
 <ul class="td-sidebar-nav__section pr-md-3">
   <li class="td-sidebar-nav__section-title">
-    <a  href="{{ $s.RelPermalink }}" class="align-left pl-0 pr-2{{ if not $show }} collapsed{{ end }}{{ if $active}} active{{ end }} td-sidebar-link td-sidebar-link__section">{{ $s.LinkTitle }}</a>
+    <a  href="{{ $s.RelPermalink }}" class="align-left pl-0 pr-2{{ if not $show }} collapsed{{ end }}{{ if $active}} active{{ end }} td-sidebar-link td-sidebar-link__section">{{ replace $s.LinkTitle "Kubernetes" $p.Site.Params.distroName }}</a>
   </li>
   <ul>
     <li class="collapse {{ if $show }}show{{ end }}" id="{{ $sid }}">
@@ -40,7 +40,7 @@
           {{ if .IsPage }}
             {{ $mid := printf "m-%s" (.RelPermalink | anchorize) }}
             {{ $active := eq . $p }}
-            <a class="td-sidebar-link td-sidebar-link__page {{ if and (not $shouldDelayActive) $active }} active{{ end }}" id="{{ $mid }}" href="{{ .RelPermalink }}">{{ .LinkTitle }}</a>
+            <a class="td-sidebar-link td-sidebar-link__page {{ if and (not $shouldDelayActive) $active }} active{{ end }}" id="{{ $mid }}" href="{{ .RelPermalink }}">{{ replace .LinkTitle "Kubernetes" .Site.Params.distroName }}</a>
           {{ else }}
             {{ template "section-tree-nav-section" (dict "page" $p "section" .) }}
           {{ end }}


### PR DESCRIPTION
There is no general way to dynamically manipulate those titles. Therefore, add a replace function in .Title to replace "Kubernetes" (the default with .Site.Params.distroName) in all relevant templates from docsy. Search is not affected though.