### PR TITLE
Disable replacing 'Kubernetes' in titles

### DIFF
--- a/content/en/docs/01/_index.md
+++ b/content/en/docs/01/_index.md
@@ -1,5 +1,5 @@
 ---
-title: "1. Quick tour of Kubernetes"
+title: "1. Introduction"
 weight: 1
 sectionnumber: 1
 ---

--- a/layouts/docs/list.html
+++ b/layouts/docs/list.html
@@ -1,6 +1,6 @@
 {{ define "main" }}
 <div class="td-content">
-	<h1>{{ replace .Title "Kubernetes" .Site.Params.distroName }}</h1>
+	<h1>{{ .Title }}</h1>
         {{ with .Params.description }}<div class="lead">{{ . | markdownify }}</div>{{ end }}
 	{{ if (and (not .Params.hide_readingtime) (.Site.Params.ui.readingtime.enable)) }}
             {{ partial "reading-time.html" . }}

--- a/layouts/partials/section-index.html
+++ b/layouts/partials/section-index.html
@@ -9,7 +9,7 @@
         <ul>
             {{ range $pages }}
                 {{ if eq .Parent $parent }}
-                    <li><a href="{{ .RelPermalink }}">{{- replace .Title "Kubernetes" .Site.Params.distroName -}}</a></li>
+                    <li><a href="{{ .RelPermalink }}">{{- .Title -}}</a></li>
                 {{ end }}
             {{ end }}
         </ul>
@@ -20,7 +20,7 @@
             {{ if eq .Parent $parent }}
                 <div class="entry">
                     <h5>
-                        <a href="{{ .RelPermalink }}">{{- replace .Title "Kubernetes" .Site.Params.distroName -}}</a>
+                        <a href="{{ .RelPermalink }}">{{- .Title -}}</a>
                     </h5>
                     <p>{{ .Description | markdownify }}</p>
                 </div>

--- a/layouts/partials/sidebar-tree.html
+++ b/layouts/partials/sidebar-tree.html
@@ -27,7 +27,7 @@
 {{ $sid := $s.RelPermalink | anchorize }}
 <ul class="td-sidebar-nav__section pr-md-3">
   <li class="td-sidebar-nav__section-title">
-    <a  href="{{ $s.RelPermalink }}" class="align-left pl-0 pr-2{{ if not $show }} collapsed{{ end }}{{ if $active}} active{{ end }} td-sidebar-link td-sidebar-link__section">{{ replace $s.LinkTitle "Kubernetes" $p.Site.Params.distroName }}</a>
+    <a  href="{{ $s.RelPermalink }}" class="align-left pl-0 pr-2{{ if not $show }} collapsed{{ end }}{{ if $active}} active{{ end }} td-sidebar-link td-sidebar-link__section">{{ $s.LinkTitle }}</a>
   </li>
   <ul>
     <li class="collapse {{ if $show }}show{{ end }}" id="{{ $sid }}">
@@ -40,7 +40,7 @@
           {{ if .IsPage }}
             {{ $mid := printf "m-%s" (.RelPermalink | anchorize) }}
             {{ $active := eq . $p }}
-            <a class="td-sidebar-link td-sidebar-link__page {{ if and (not $shouldDelayActive) $active }} active{{ end }}" id="{{ $mid }}" href="{{ .RelPermalink }}">{{ replace .LinkTitle "Kubernetes" .Site.Params.distroName }}</a>
+            <a class="td-sidebar-link td-sidebar-link__page {{ if and (not $shouldDelayActive) $active }} active{{ end }}" id="{{ $mid }}" href="{{ .RelPermalink }}">{{ .LinkTitle }}</a>
           {{ else }}
             {{ template "section-tree-nav-section" (dict "page" $p "section" .) }}
           {{ end }}


### PR DESCRIPTION
This merge request disables the replacement of 'Kubernetes' in titles. This is needed for the new OpenShift lab 14 title to render correctly.