### PR TITLE
Update OpenShift versions

### DIFF
--- a/content/en/docs/02/_index.md
+++ b/content/en/docs/02/_index.md
@@ -203,9 +203,9 @@ Now paste the copied command in your shell.
 If you now execute `oc version` you should see something like this (version numbers may vary):
 
 ```
-Client Version: 4.5.7
-Server Version: 4.5.7
-Kubernetes Version: v1.18.3+2cf11e2
+Client Version: 4.6.9
+Server Version: 4.6.9
+Kubernetes Version: v1.19.0+7070803
 ```
 
 

--- a/content/en/docs/09/03/_index.md
+++ b/content/en/docs/09/03/_index.md
@@ -73,5 +73,5 @@ The CronJob's definition will remind you of the Deployment's structure, or reall
 Further information can be found in the [Kubernetes CronJob documentation](https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/).
 {{% /onlyWhenNot %}}
 {{% onlyWhen openshift %}}
-Further information can be found in the [OpenShift CronJob documentation](https://docs.openshift.com/container-platform/4.6/nodes/jobs/nodes-nodes-jobs.html).
+Further information can be found in the [OpenShift CronJob documentation](https://docs.openshift.com/container-platform/latest/nodes/jobs/nodes-nodes-jobs.html).
 {{% /onlyWhen %}}

--- a/content/en/docs/09/06/_index.md
+++ b/content/en/docs/09/06/_index.md
@@ -124,7 +124,7 @@ Check [Init Container](https://kubernetes.io/docs/concepts/workloads/pods/init-c
 
 A similar concepts are the so called pre and post deployment hooks. Those hooks basically give the possibility to execute pods during before and after a deployment is in progress
 
-Check out the [official documentation](https://docs.openshift.com/container-platform/4.6/applications/deployments/deployment-strategies.html) for further information.
+Check out the [official documentation](https://docs.openshift.com/container-platform/latest/applications/deployments/deployment-strategies.html) for further information.
 {{% /onlyWhen %}}
 
 

--- a/content/en/setup/04/_index.md
+++ b/content/en/setup/04/_index.md
@@ -26,7 +26,7 @@ Client Version: version.Info{Major:"1", Minor:"18", GitVersion:"v1.18.0", GitCom
 {{% onlyWhen openshift %}}
 
 ```
-Client Version: 4.5.7
+Client Version: 4.6.9
 ...
 ```
 
@@ -39,7 +39,7 @@ If you don't see a similar output, possibly there are issues with the `PATH` var
 Make sure to use at least version 1.16.x for your `kubectl`
 {{% /onlyWhenNot %}}
 {{% onlyWhen openshift %}}
-Make sure to use at least `oc` version `4.5.x`.
+Make sure to use at least `oc` version `4.6.x`.
 {{% /onlyWhen %}}
 
 {{% /alert %}}


### PR DESCRIPTION
Update versions and reference 'latest' instead of a specific in documentation URLs.