### PR TITLE
Small fixes

### DIFF
--- a/content/en/docs/09/05/_index.md
+++ b/content/en/docs/09/05/_index.md
@@ -318,7 +318,7 @@ spec:
 And apply this again with:
 
 ```bash
-{{% param cliToolName %}} kubectl apply -f pod_stress_resources.yaml
+{{% param cliToolName %}} apply -f pod_stress_resources.yaml
 ```
 
 
@@ -361,7 +361,7 @@ spec:
 ```
 
 ```bash
-{{% param cliToolName %}} kubectl apply -f pod_overbooked.yaml
+{{% param cliToolName %}} apply -f pod_overbooked.yaml
 ```
 
 We are immediately confronted with an error message:
@@ -424,7 +424,7 @@ spec:
 And apply with:
 
 ```bash
-{{% param cliToolName %}} kubectl apply -f pod_overbooked.yaml
+{{% param cliToolName %}} apply -f pod_overbooked.yaml
 ```
 
 Even though the limits of both Pods combined overstretch the quota, the requests do not and so the Pods are allowed to run.

--- a/content/en/docs/09/05/_index.md
+++ b/content/en/docs/09/05/_index.md
@@ -211,7 +211,7 @@ spec:
 apply this resource with:
 
 ```bash
-{{% param cliToolName %}} kubectl apply -f pod_stress.yaml
+{{% param cliToolName %}} apply -f pod_stress.yaml
 ```
 
 

--- a/content/en/docs/11/simplechart.md
+++ b/content/en/docs/11/simplechart.md
@@ -182,6 +182,7 @@ ingress:
     - host: mychart-<namespace>.<appdomain>
       paths:
         - path: /
+          pathType: ImplementationSpecific
   tls:
     - secretName: mychart-<namespace>-<appdomain>
       hosts:

--- a/content/en/docs/12/kustomize/base/deployment.yaml
+++ b/content/en/docs/12/kustomize/base/deployment.yaml
@@ -18,7 +18,7 @@ spec:
             - name: APPLICATION_NAME
               value: app-base
           command:
-            - bash
+            - sh
             - -c
             - |-
               set -e


### PR DESCRIPTION
* Chaning some occurences of "oc kubectl apply" to "oc apply"
* Adding "pathType" to Ingress resource which otherwise leads to an error
* Changing from 'bash' to 'sh' in the command of the kustomize deployment, as there is no bash available in the used image