### PR TITLE
Fix overbooked pod resource limit

### DIFF
--- a/content/en/docs/09/05/_index.md
+++ b/content/en/docs/09/05/_index.md
@@ -422,7 +422,7 @@ spec:
     resources:
       limits:
         cpu: 100m
-        memory: 16Mi
+        memory: 50Mi
       requests:
         cpu: 10m
         memory: 10Mi


### PR DESCRIPTION
With a lower limit the pod strangely cannot be started.