### PR TITLE
move Issuer for techlab to acend ClusterIssuer

### DIFF
--- a/helm-chart/values.yaml
+++ b/helm-chart/values.yaml
@@ -69,6 +69,7 @@ acendTraining:
         annotations:
           kubernetes.io/ingress.class: nginx-public
           kubernetes.io/tls-acme: "true"
+          cert-manager.io/cluster-issuer: acend-letsencrypt
         appname: techlab
         domain: training.acend.ch
         domainmain: appuio.ch


### PR DESCRIPTION
This Cert was issued with the default puzzle ClusterIssuer with a Puzzle Mail. Change to our ClusterIssuer