### PR TITLE
Nginx redirects

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,4 +35,5 @@ LABEL org.opencontainers.image.licenses CC-BY-SA-4.0
 EXPOSE 8080
 
 COPY --from=builder /src/public /usr/share/nginx/html
+COPY --from=builder /src/nginx.conf.template /etc/nginx/templates/default.conf.template
 COPY --from=wkhtmltopdf /pdf.pdf /usr/share/nginx/html/pdf/pdf.pdf

--- a/nginx.conf.template
+++ b/nginx.conf.template
@@ -1,0 +1,29 @@
+server {
+    listen       8080;
+    server_name  localhost;
+
+    location / {
+        root   /usr/share/nginx/html;
+        index  index.html index.htm;
+    }
+
+    # redirect server error pages to the static page /50x.html
+    #
+    error_page   500 502 503 504  /50x.html;
+    location = /50x.html {
+        root   /usr/share/nginx/html;
+    }
+
+    # redirects issued by nginx will be relative
+    #
+    absolute_redirect off;
+
+    # acend redirects
+    #
+    location = /slides/ {
+        return 301 /materials/;
+    }
+}
+
+
+

--- a/nginx.conf.template
+++ b/nginx.conf.template
@@ -24,6 +24,3 @@ server {
         return 301 /materials/;
     }
 }
-
-
-


### PR DESCRIPTION
Some users already bookmarked or documented the old `/slides/` URI which now leads to a 404. This PR adds a redirect so that requests to `/slides/` get a 301 to `/materials/`.