### PR TITLE
Adapt verbosity example

### DIFF
--- a/content/en/docs/troubleshooting/_index.md
+++ b/content/en/docs/troubleshooting/_index.md
@@ -218,7 +218,7 @@ The following `{{% param cliToolName %}}` subcommands support this flag (non-fin
 For example, we can use the `--dry-run=client` flag to create a template for our Deployment:
 
 ```bash
-{{% param cliToolName %}} create deployment example-web-go --image=quay.io/acend/example-web-go:latest --namespace acend-test --dry-run=client -o yaml
+{{% param cliToolName %}} create deployment example-web-go --image={{% param "images.acendAwesomeApp-example-web-go" %}} --namespace acend-test --dry-run=client -o yaml
 ```
 
 The result is the following YAML output:
@@ -259,29 +259,37 @@ If you want to see the HTTP requests `{{% param cliToolName %}}` sends to the Ku
 For example, to see the API request for creating a namespace:
 
 ```bash
-{{% param cliToolName %}} create namespace acend-test --v=10
+{{% param cliToolName %}} create deployment example-web-go --image={{% param "images.acendAwesomeApp-example-web-go" %}} --namespace acend-test --replicas=0 --v=10
 ```
 
 The resulting output looks like this:
 
 ```bash
-I1109 16:42:21.438803  268345 request.go:1073] Request Body: {"kind":"Namespace","apiVersion":"v1","metadata":{"name":"acend-test","creationTimestamp":null},"spec":{},"status":{}}
-I1109 16:42:21.438862  268345 round_trippers.go:466] curl -v -XPOST  -H "Accept: application/json, */*" -H "Content-Type: application/json" -H "User-Agent: oc/4.11.0 (linux/amd64) kubernetes/7075089" -H "Authorization: Bearer <masked>" 'https://api.training.openshift.ch:6443/api/v1/namespaces?fieldManager=kubectl-create&fieldValidation=Ignore'
-I1109 16:42:21.468590  268345 round_trippers.go:495] HTTP Trace: DNS Lookup for api.training.openshift.ch resolved to [{16.170.14.174 } {13.53.141.154 } {13.49.184.94 }]
-I1109 16:42:21.520614  268345 round_trippers.go:510] HTTP Trace: Dial to tcp:16.170.14.174:6443 succeed
-I1109 16:42:21.705733  268345 round_trippers.go:553] POST https://api.training.openshift.ch:6443/api/v1/namespaces?fieldManager=kubectl-create&fieldValidation=Ignore 201 Created in 266 milliseconds
-I1109 16:42:21.705849  268345 round_trippers.go:570] HTTP Statistics: DNSLookup 29 ms Dial 51 ms TLSHandshake 103 ms ServerProcessing 81 ms Duration 266 ms
-I1109 16:42:21.705900  268345 round_trippers.go:577] Response Headers:
-I1109 16:42:21.705955  268345 round_trippers.go:580]     Audit-Id: dd52d6eb-5479-4960-9367-09f5571dd779
-I1109 16:42:21.705999  268345 round_trippers.go:580]     Cache-Control: no-cache, private
-I1109 16:42:21.706049  268345 round_trippers.go:580]     Content-Type: application/json
-I1109 16:42:21.706154  268345 round_trippers.go:580]     X-Kubernetes-Pf-Flowschema-Uid: 950aa9cf-a0c2-4b42-943b-41b1b73921bf
-I1109 16:42:21.706216  268345 round_trippers.go:580]     X-Kubernetes-Pf-Prioritylevel-Uid: ff295cbf-f8c0-4327-9ec6-625f04de293d
-I1109 16:42:21.706277  268345 round_trippers.go:580]     Content-Length: 530
-I1109 16:42:21.706336  268345 round_trippers.go:580]     Date: Wed, 09 Nov 2022 15:42:21 GMT
-I1109 16:42:21.706527  268345 request.go:1073] Response Body: {"kind":"Namespace","apiVersion":"v1","metadata":{"name":"acend-test","uid":"19edb3ff-0beb-4c72-a2bb-297c5bde08c5","resourceVersion":"8783080","creationTimestamp":"2022-11-09T15:42:21Z","labels":{"kubernetes.io/metadata.name":"acend-test"},"managedFields":[{"manager":"kubectl-create","operation":"Update","apiVersion":"v1","time":"2022-11-09T15:42:21Z","fieldsType":"FieldsV1","fieldsV1":{"f:metadata":{"f:labels":{".":{},"f:kubernetes.io/metadata.name":{}}}}}]},"spec":{"finalizers":["kubernetes"]},"status":{"phase":"Active"}}
-namespace/acend-test created
+I1114 15:31:13.605759   85289 request.go:1073] Request Body: {"kind":"Deployment","apiVersion":"apps/v1","metadata":{"name":"test-deployment","namespace":"acend-test","creationTimestamp":null,"labels":{"app":"test-deployment"}},"spec":{"replicas":0,"selector":{"matchLabels":{"app":"test-deployment"}},"template":{"metadata":{"creationTimestamp":null,"labels":{"app":"test-deployment"}},"spec":{"containers":[{"name":"example-web-go","image":"quay.io/acend/example-web-go:latest","resources":{}}]}},"strategy":{}},"status":{}}
+I1114 15:31:13.605817   85289 round_trippers.go:466] curl -v -XPOST  -H "Accept: application/json, */*" -H "Content-Type: application/json" -H "User-Agent: oc/4.11.0 (linux/amd64) kubernetes/262ac9c" -H "Authorization: Bearer <masked>" 'https://api.ocp-staging.cloudscale.puzzle.ch:6443/apis/apps/v1/namespaces/acend-test/deployments?fieldManager=kubectl-create&fieldValidation=Ignore'
+I1114 15:31:13.607320   85289 round_trippers.go:495] HTTP Trace: DNS Lookup for api.ocp-staging.cloudscale.puzzle.ch resolved to [{5.102.150.82 }]
+I1114 15:31:13.611279   85289 round_trippers.go:510] HTTP Trace: Dial to tcp:5.102.150.82:6443 succeed
+I1114 15:31:13.675096   85289 round_trippers.go:553] POST https://api.ocp-staging.cloudscale.puzzle.ch:6443/apis/apps/v1/namespaces/acend-test/deployments?fieldManager=kubectl-create&fieldValidation=Ignore 201 Created in 69 milliseconds
+I1114 15:31:13.675120   85289 round_trippers.go:570] HTTP Statistics: DNSLookup 1 ms Dial 3 ms TLSHandshake 35 ms ServerProcessing 27 ms Duration 69 ms
+I1114 15:31:13.675137   85289 round_trippers.go:577] Response Headers:
+I1114 15:31:13.675151   85289 round_trippers.go:580]     Audit-Id: 509255b1-ee23-479a-be56-dfc3ab073864
+I1114 15:31:13.675164   85289 round_trippers.go:580]     Cache-Control: no-cache, private
+I1114 15:31:13.675181   85289 round_trippers.go:580]     Content-Type: application/json
+I1114 15:31:13.675200   85289 round_trippers.go:580]     X-Kubernetes-Pf-Flowschema-Uid: e3e152ee-768c-43c5-b350-bb3cbf806147
+I1114 15:31:13.675215   85289 round_trippers.go:580]     X-Kubernetes-Pf-Prioritylevel-Uid: 47f392da-68d1-4e43-9d77-ff5f7b7ecd2e
+I1114 15:31:13.675230   85289 round_trippers.go:580]     Content-Length: 1739
+I1114 15:31:13.675244   85289 round_trippers.go:580]     Date: Mon, 14 Nov 2022 14:31:13 GMT
+I1114 15:31:13.676116   85289 request.go:1073] Response Body: {"kind":"Deployment","apiVersion":"apps/v1","metadata":{"name":"test-deployment","namespace":"acend-test","uid":"a6985d28-3caa-451f-a648-4c7cde3b51ac","resourceVersion":"2069385577","generation":1,"creationTimestamp":"2022-11-14T14:31:13Z","labels":{"app":"test-deployment"},"managedFields":[{"manager":"kubectl-create","operation":"Update","apiVersion":"apps/v1","time":"2022-11-14T14:31:13Z","fieldsType":"FieldsV1","fieldsV1":{"f:metadata":{"f:labels":{".":{},"f:app":{}}},"f:spec":{"f:progressDeadlineSeconds":{},"f:replicas":{},"f:revisionHistoryLimit":{},"f:selector":{},"f:strategy":{"f:rollingUpdate":{".":{},"f:maxSurge":{},"f:maxUnavailable":{}},"f:type":{}},"f:template":{"f:metadata":{"f:labels":{".":{},"f:app":{}}},"f:spec":{"f:containers":{"k:{\"name\":\"example-web-go\"}":{".":{},"f:image":{},"f:imagePullPolicy":{},"f:name":{},"f:resources":{},"f:terminationMessagePath":{},"f:terminationMessagePolicy":{}}},"f:dnsPolicy":{},"f:restartPolicy":{},"f:schedulerName":{},"f:securityContext":{},"f:terminationGracePeriodSeconds":{}}}}}}]},"spec":{"replicas":0,"selector":{"matchLabels":{"app":"test-deployment"}},"template":{"metadata":{"creationTimestamp":null,"labels":{"app":"test-deployment"}},"spec":{"containers":[{"name":"example-web-go","image":"quay.io/acend/example-web-go:latest","resources":{},"terminationMessagePath":"/dev/termination-log","terminationMessagePolicy":"File","imagePullPolicy":"Always"}],"restartPolicy":"Always","terminationGracePeriodSeconds":30,"dnsPolicy":"ClusterFirst","securityContext":{},"schedulerName":"default-scheduler"}},"strategy":{"type":"RollingUpdate","rollingUpdate":{"maxUnavailable":"25%","maxSurge":"25%"}},"revisionHistoryLimit":10,"progressDeadlineSeconds":600},"status":{}}
+deployment.apps/test-deployment created
 ```
 
 As you can see, the output conveniently contains the corresponding `curl` commands which we could use in our own code, tools, pipelines etc.
 
+{{% alert title="Note" color="info" %}}
+If you created the deployment to see the output, you can delete it again as it's not used anywhere else (which is also the reason why the replicas are set to `0`):
+
+```bash
+{{% param cliToolName %}} delete test-deployment
+```
+
+{{% /alert %}}


### PR DESCRIPTION
Create a deployment with `--v=0` instead of a namespace so we don't hit any potential permissions problems.