### PR TITLE
fix mysqld-exporter tag to v0.14.0 (breaking changes in new version)

### DIFF
--- a/content/en/docs/additional-concepts/sidecar-containers/deploy_mariadb-sidecar.yaml
+++ b/content/en/docs/additional-concepts/sidecar-containers/deploy_mariadb-sidecar.yaml
@@ -1,6 +1,6 @@
       containers:
       - ...
-      - image: docker.io/prom/mysqld-exporter
+      - image: docker.io/prom/mysqld-exporter:v0.14.0
         name: mysqld-exporter
         env:
         - name: MYSQL_DATABASE_ROOT_PASSWORD


### PR DESCRIPTION
v0.15 of prometheus exporter has a breaking change so we fix it to the older version
Should maybe be fixed as well for Baloise