### PR TITLE
Remove suspend line

### DIFF
--- a/content/en/docs/additional-concepts/cronjobs-and-jobs/cronjob-mariadb-dump.yaml
+++ b/content/en/docs/additional-concepts/cronjobs-and-jobs/cronjob-mariadb-dump.yaml
@@ -6,7 +6,6 @@ spec:
   schedule: "5 4 * * *"
   concurrencyPolicy: "Replace"
   startingDeadlineSeconds: 200
-  suspend: true
   successfulJobsHistoryLimit: 3
   failedJobsHistoryLimit: 1
   jobTemplate:


### PR DESCRIPTION
This makes sure we provide a functional example. Users are less confused that their CronJob is not working because `suspend: true` was set from the example.